### PR TITLE
lttoolbox is switching to ICU, so the interface is changing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.61)
 
-AC_INIT([lexd], [1.0.0], [awesomeevildudes@gmail.com])
+AC_INIT([lexd], [1.1.0], [awesomeevildudes@gmail.com])
 AM_INIT_AUTOMAKE
 AC_CONFIG_MACRO_DIR([m4])
 
@@ -15,7 +15,7 @@ AC_ARG_ENABLE(debug,
               [  --enable-debug  Enable "-g" compiler options],
               [CXXFLAGS="-g $CXXFLAGS";CFLAGS="-g $CFLAGS"])
 
-PKG_CHECK_MODULES([LTTOOLBOX], [lttoolbox >= 3.5.3])
+PKG_CHECK_MODULES([LTTOOLBOX], [lttoolbox >= 3.6.0])
 PKG_CHECK_MODULES([ICU_UC], [icu-uc])
 PKG_CHECK_MODULES([ICU_IO], [icu-io])
 

--- a/src/icu-iter.cc
+++ b/src/icu-iter.cc
@@ -188,38 +188,9 @@ pair<int, int> char_iter::span() const
   return it.span();
 }
 
-std::wstring to_wstring(const UnicodeString &str)
+UString to_ustring(const UnicodeString &str)
 {
-  auto buf = str.getBuffer();
-  if(!buf)
-  {
-    cerr << "buffer is null" << endl;
-    exit(1);
-  }
-
-  UErrorCode result = U_ZERO_ERROR;
-  int32_t wlen = 0;
-  u_strToWCS(NULL, 0, &wlen, buf, str.length(), &result);
-  if (U_FAILURE(result) && result != U_BUFFER_OVERFLOW_ERROR) {
-    cerr << "Error decoding unicode string; error code " << result;
-    cerr << "; the string was length " << str.length() << endl;
-    exit(1);
-  }
-
-  result = U_ZERO_ERROR;
-
-  int32_t written = 0;
-  wstring wc(static_cast<size_t>(wlen+1), 0);
-  u_strToWCS(&wc[0], wlen+1, &written, buf, str.length(), &result);
-  if (result) {
-    cerr << "Error decoding unicode string; error code " << result << endl;;
-    exit(1);
-  }
-  if (written != wlen) {
-    cerr << "Wrote " << written << " wchar_t when " << wlen << " was expected";
-    exit(1);
-  }
-
-  wc.resize(static_cast<size_t>(wlen));
-  return wc;
+  UString temp;
+  temp.append(str.getBuffer(), str.length());
+  return temp;
 }

--- a/src/icu-iter.h
+++ b/src/icu-iter.h
@@ -5,6 +5,7 @@
 #include <unicode/uchar.h>
 #include <unicode/unistr.h>
 #include <unicode/ustring.h>
+#include <lttoolbox/ustring.h>
 #include <map>
 #include <string>
 
@@ -62,6 +63,6 @@ class char_iter
 
 char_iter rev_char_iter(const icu::UnicodeString &s);
 
-std::wstring to_wstring(const icu::UnicodeString &str);
+UString to_ustring(const icu::UnicodeString &str);
 
 #endif

--- a/src/lexd.cc
+++ b/src/lexd.cc
@@ -169,10 +169,10 @@ int main(int argc, char *argv[])
     //write_le(output, features);
 
     // letters
-    //Compression::wstring_write(L"", output);
+    //Compression::string_write(""_u, output);
     //comp.alphabet.write(output);
     //Compression::multibyte_write(1, output);
-    //Compression::wstring_write(L"main", output);
+    //Compression::string_write("main"_u, output);
     //transducer->write(output);
   }
   else

--- a/src/lexd.cc
+++ b/src/lexd.cc
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
   bool single = false;
   bool stats = false;
   UFILE* input = u_finit(stdin, NULL, NULL);
-  FILE* output = stdout;
+  UFILE* output = u_finit(stdout, NULL, NULL);
   LexdCompiler comp;
 
   LtLocale::tryToSetLocale();
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
 
   if(outfile != "" && outfile != "-")
   {
-    output = fopen(outfile.c_str(), "wb");
+    output = u_fopen(outfile.c_str(), "wb", NULL, NULL);
     if(!output)
     {
       cerr << "Error: Cannot open file '" << outfile << "' for writing." << endl;
@@ -173,13 +173,13 @@ int main(int argc, char *argv[])
     //comp.alphabet.write(output);
     //Compression::multibyte_write(1, output);
     //Compression::wstring_write(L"main", output);
-    transducer->write(output);
+    //transducer->write(output);
   }
   else
   {
     transducer->show(comp.alphabet, output, 0, true);
   }
-  if(output != stdout) fclose(output);
+  u_fclose(output);
   delete transducer;
   return 0;
 }

--- a/src/lexdcompiler.cc
+++ b/src/lexdcompiler.cc
@@ -621,7 +621,7 @@ LexdCompiler::processNextLine()
   bool escape = false;
   bool comment = false;
   bool lastWasSpace = false;
-  while((c = u_fgetc(input)) != L'\n')
+  while((c = u_fgetc(input)) != '\n')
   {
     bool space = false;
     if(c == U_EOF)
@@ -635,12 +635,12 @@ LexdCompiler::processNextLine()
       line += c;
       escape = false;
     }
-    else if(c == L'\\')
+    else if(c == '\\')
     {
       escape = true;
       line += c;
     }
-    else if(c == L'#')
+    else if(c == '#')
     {
       comment = true;
     }
@@ -703,7 +703,7 @@ LexdCompiler::processNextLine()
       for(int i = name.length()-2; i > 0; i--)
       {
         if(u_isdigit(name[i])) num = name[i] + num;
-        else if(name[i] == L'(' && num.length() > 0)
+        else if(name[i] == '(' && num.length() > 0)
         {
           currentLexiconPartCount = (unsigned int)StringUtils::stoi(to_ustring(num));
           name = name.retainBetween(0, i);

--- a/src/lexdcompiler.cc
+++ b/src/lexdcompiler.cc
@@ -63,13 +63,13 @@ const UnicodeString &LexdCompiler::name(string_ref r) const
 
 trans_sym_t LexdCompiler::alphabet_lookup(const UnicodeString &symbol)
 {
-  wstring wsymbol = to_wstring(symbol);
-  if(wsymbol.length() == 1)
-    return trans_sym_t((int)wsymbol[0]);
-  else
-  {
-    alphabet.includeSymbol(wsymbol);
-    return trans_sym_t(alphabet(wsymbol));
+  if (!symbol.hasMoreChar32Than(0, symbol.length(), 1)) {
+    return trans_sym_t((int)symbol.char32At(0));
+  } else {
+    UString temp;
+    temp.append(symbol.getBuffer(), symbol.length());
+    alphabet.includeSymbol(temp);
+    return trans_sym_t(alphabet(temp));
   }
 }
 trans_sym_t LexdCompiler::alphabet_lookup(trans_sym_t l, trans_sym_t r)

--- a/src/lexdcompiler.h
+++ b/src/lexdcompiler.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <set>
 #include <memory>
+#include <cstdarg>
 
 using namespace std;
 using namespace icu;
@@ -346,7 +347,7 @@ private:
   vector<pattern_element_t> left_sieve_tok;
   vector<pattern_element_t> right_sieve_tok;
 
-  void die(const wstring & msg);
+  void die(const char* msg, ...);
   void finishLexicon();
   string_ref internName(const UnicodeString& name);
   string_ref checkName(UnicodeString& name);

--- a/src/lexicon.cc
+++ b/src/lexicon.cc
@@ -95,7 +95,9 @@ Lexicon::getTransducerWithFlags(Alphabet& alpha, Side side, unsigned int part, w
     int state = t->getInitial();
     if(flag.size() > 0)
     {
-      wstring f = L"@U." + flag + L"." + to_wstring(e) + L"@";
+      UChar buf[64];
+      u_snprintf(buf, 64, "@U.%S.%d@", flag.c_str(), e);
+      UString f = buf;
       alpha.includeSymbol(f);
       int s = alpha(f);
       state = t->insertSingleTransduction(alpha(s, s), state);

--- a/src/lexicon.cc
+++ b/src/lexicon.cc
@@ -87,7 +87,7 @@ Lexicon::getTransducer(Alphabet& alpha, Side side, unsigned int part, unsigned i
 }
 
 Transducer*
-Lexicon::getTransducerWithFlags(Alphabet& alpha, Side side, unsigned int part, wstring flag)
+Lexicon::getTransducerWithFlags(Alphabet& alpha, Side side, unsigned int part, UString flag)
 {
   Transducer* t = new Transducer();
   for(unsigned int e = 0; e < entries.size(); e++)

--- a/src/lexicon.h
+++ b/src/lexicon.h
@@ -33,7 +33,7 @@ public:
   ~Lexicon();
   void addEntries(vector<vector<pair<vector<int>, vector<int>>>> newEntries);
   Transducer* getTransducer(Alphabet& alpha, Side side, unsigned int part, unsigned int index);
-  Transducer* getTransducerWithFlags(Alphabet& alpha, Side side, unsigned int part, wstring flag);
+  Transducer* getTransducerWithFlags(Alphabet& alpha, Side side, unsigned int part, UString flag);
   unsigned int getEntryCount()
   {
     return entryCount;


### PR DESCRIPTION
make `die()` `printf`-like and convert other `std::wstring`s to `UString`s.